### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://d3vt34m.visualstudio.com/ec9de25f-dac5-46f8-a97b-427be9e14cbd/11659b76-e13f-4711-a859-2fdf28104b10/_apis/work/boardbadge/cc5b2898-7e7e-4a62-b47c-c6ec5724c985)](https://d3vt34m.visualstudio.com/ec9de25f-dac5-46f8-a97b-427be9e14cbd/_boards/board/t/11659b76-e13f-4711-a859-2fdf28104b10/Microsoft.RequirementCategory)
 [![Build Status](https://dev.azure.com/jcsemprit/AZ%20DevOps%20and%20GitHub%20integration/_apis/build/status/sempjc.azure-and-github-ci-cd-poc?branchName=main)](https://dev.azure.com/jcsemprit/AZ%20DevOps%20and%20GitHub%20integration/_build/latest?definitionId=1&branchName=main)
 
 # azure-and-github-ci-cd-poc


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://d3vt34m.visualstudio.com/ec9de25f-dac5-46f8-a97b-427be9e14cbd/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.